### PR TITLE
Add SNI extension

### DIFF
--- a/filter-ssl/src/main/java/org/wso2/org/apache/mina/filter/SSLFilter.java
+++ b/filter-ssl/src/main/java/org/wso2/org/apache/mina/filter/SSLFilter.java
@@ -19,6 +19,8 @@
  */
 package org.wso2.org.apache.mina.filter;
 
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
@@ -131,6 +133,9 @@ public class SSLFilter extends IoFilterAdapter {
 
     private static final String SSL_HANDLER = SSLFilter.class.getName()
             + ".SSLHandler";
+
+    public static final String PEER_ADDRESS = SSLFilter.class.getName()
+            + ".PeerAddress";
     
     // SSL Context
     private SSLContext sslContext;
@@ -327,6 +332,13 @@ public class SSLFilter extends IoFilterAdapter {
 
         IoSession session = parent.getSession();
         session.setAttribute(NEXT_FILTER, nextFilter);
+
+        SocketAddress remoteAddress = session.getRemoteAddress();
+
+        if (remoteAddress instanceof InetSocketAddress) {
+            // activate the SNI support in the JSSE SSLEngine
+            session.setAttribute(PEER_ADDRESS, remoteAddress);
+        }
 
         // Create an SSL handler and start handshake.
         SSLHandler handler = new SSLHandler(this, sslContext, session);

--- a/filter-ssl/src/main/java/org/wso2/org/apache/mina/filter/support/SSLHandler.java
+++ b/filter-ssl/src/main/java/org/wso2/org/apache/mina/filter/support/SSLHandler.java
@@ -26,6 +26,7 @@ import org.wso2.org.apache.mina.filter.SSLFilter;
 import org.wso2.org.apache.mina.util.SessionLog;
 import org.wso2.org.apache.mina.common.IoFilter;
 
+import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.LinkedList;
 import java.util.Queue;
@@ -126,8 +127,15 @@ public class SSLHandler {
         if (sslEngine != null) {
             return;
         }
+        
+        InetSocketAddress peer = (InetSocketAddress) session.getAttribute(SSLFilter.PEER_ADDRESS);
 
-        sslEngine = ctx.createSSLEngine();
+        // Create the SSL engine here
+        if (peer == null) {
+            sslEngine = ctx.createSSLEngine();
+        } else {
+            sslEngine = ctx.createSSLEngine(peer.getHostName(), peer.getPort());
+        }
         sslEngine.setUseClientMode(parent.isUseClientMode());
 
         if (parent.isWantClientAuth()) {


### PR DESCRIPTION
## Purpose

- Added Server Name Indication(SNI) to the SSL communication between JMS of traffic manager node and gateway node.
- Related to https://github.com/wso2/api-manager/issues/1967.

## Approach
- Took peer address and derived the hostname.